### PR TITLE
Update http headers when pull image with no cache

### DIFF
--- a/api/src/main/java/org/hisp/dhis/android/dashboard/api/controllers/PullImageController.java
+++ b/api/src/main/java/org/hisp/dhis/android/dashboard/api/controllers/PullImageController.java
@@ -105,6 +105,7 @@ final class PullImageController {
         for (int i = 0; i < requestUrlList.size(); i++) {
             final String request = requestUrlList.get(i);
             if (imageNetworkPolicy == DhisController.ImageNetworkPolicy.NO_CACHE) {
+                PicassoProvider.getInstance(context, false).invalidate(request);
                 PicassoProvider.getInstance(context, false)
                         .load(request).networkPolicy(NetworkPolicy.NO_CACHE)
                         .memoryPolicy(MemoryPolicy.NO_CACHE).fetch();

--- a/api/src/main/java/org/hisp/dhis/android/dashboard/api/utils/PicassoProvider.java
+++ b/api/src/main/java/org/hisp/dhis/android/dashboard/api/utils/PicassoProvider.java
@@ -30,17 +30,12 @@ package org.hisp.dhis.android.dashboard.api.utils;
 
 import android.content.Context;
 
-import com.squareup.okhttp.Cache;
-import com.squareup.okhttp.Interceptor;
 import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Response;
 import com.squareup.picasso.OkHttpDownloader;
 import com.squareup.picasso.Picasso;
 
 import org.hisp.dhis.android.dashboard.api.controllers.DhisController;
 import org.hisp.dhis.android.dashboard.api.network.RepoManager;
-
-import java.io.IOException;
 
 public final class PicassoProvider {
 


### PR DESCRIPTION
Closes #127 
How test it?
Open a dashboard, open a dashboard item.
Change the Type image(top left of the dashboard). 
Click on update.
Click on favorites->save.
Click on favorites->get link-> Copy the url "Open in web api"

If you was loaded the url before update, you will need refresh the navigator cache to see the new imagen in the navigator (for example* control+f5).